### PR TITLE
#None Make it possible configure allowed non namespaced topics from helm chart

### DIFF
--- a/charts/knuto/templates/deployment.yaml
+++ b/charts/knuto/templates/deployment.yaml
@@ -76,6 +76,11 @@ spec:
         {{- if eq $config.deletion_enabled true }}
         - --enable-topic-deletion
         {{- end }}
+        - --allowed-non-namespaced-topics
+        {{- range $config.allowed_non_namespaced_topics }}
+        - {{ . }}
+        {{- end }}
+        - --
         - {{ $namespace }}
 {{ end }}
 

--- a/charts/knuto/values.yaml
+++ b/charts/knuto/values.yaml
@@ -6,10 +6,13 @@ strimzi_namespace: kafka
 kafkauser_source_namespaces:
   production:
     deletion_enabled: false
+    allowed_non_namespaced_topics: []
   latest:
     deletion_enabled: false
+    allowed_non_namespaced_topics: []
   dev:
     deletion_enabled: true
+    allowed_non_namespaced_topics: []
 
 # secret_type_to_bootstrap_server -- MApping of secret type to the DNS name an port of the Kafka service. Used to construct kafka-client.properties in Secrets placed in the namespaces configured in kafkauser_source_namespaces
 secret_type_to_bootstrap_server:

--- a/charts/knuto/values.yaml
+++ b/charts/knuto/values.yaml
@@ -1,5 +1,5 @@
 # image -- Which knuto docker image to install
-image: 036535796760.dkr.ecr.eu-west-1.amazonaws.com/erfor/knuto:f83fdc4
+image: niradynamics/knuto:a1d35fb
 # strimzi_namespace -- The namespace in which the Strimzi User and Topic operator listens for KafkaUser and KafkaTopic CRDs.
 strimzi_namespace: kafka
 # kafkauser_source_namespace -- Mapping of namespaces, with the setting for enabling or disabling deletion of KafkaTopic CRDs when they are removed in each namespace. One KNUTO instance will be started per namespace.


### PR DESCRIPTION
This extends the helm chart to make it possible to configure allowed-non-namespaced-topics for any of the source namespaces. 